### PR TITLE
Update settings of favonia/cloudflare-ddns

### DIFF
--- a/cf-dns/docker-compose.yml
+++ b/cf-dns/docker-compose.yml
@@ -4,17 +4,13 @@ services:
      image: favonia/cloudflare-ddns:latest
      network_mode: host
      restart: always
-     cap_add:
-       - SETUID
-       - SETGID
+     user: "1000:1000"
      cap_drop:
        - all
      read_only: true
      security_opt:
        - no-new-privileges:true
      environment:
-       - PUID=1000
-       - PGID=1000
        - CF_API_TOKEN=${CF_API_TOKEN}
        - DOMAINS=*.code.msws.xyz
        - PROXIED=false
@@ -22,17 +18,13 @@ services:
 #   image: favonia/cloudflare-ddns:latest
 #    network_mode: host
 #    restart: always
-#    cap_add:
-#      - SETUID
-#      - SETGID
+#    user: "1000:1000"
 #    cap_drop:
 #      - all
 #    read_only: true
 #    security_opt:
 #      - no-new-privileges:true
 #    environment:
-#      PUID: 1000
-#      PGID: 1000
 #      CF_API_TOKEN: ${CF_API_TOKEN}
 #      DOMAINS: "go.msws.xyz"
 #      PROXIED: "true"


### PR DESCRIPTION
Thanks for using my DDNS updater. Since [version 1.13.0 released on 16 July](https://github.com/favonia/cloudflare-ddns/blob/main/CHANGELOG.markdown#1130-2024-07-16), the updater has stopped dropping superuser privileges by itself, instead relying on Docker's built-in mechanism to drop those privileges. The new way is safer and more reliable, but it made the old Docker template (which grants `SETUID` and `SETGID`) potentially less secure. I am on a mission to eliminate the old template from the internet. Please help me promote security best practices!

For more information about this design change, please read the [CHANGELOG](https://github.com/favonia/cloudflare-ddns/blob/main/CHANGELOG.markdown). If copyright ever matters, this PR itself is licensed under [CC0](https://choosealicense.com/licenses/cc0-1.0/), which should allow you to do whatever you want. Thank you again for your interest in my DDNS updater.